### PR TITLE
Updated fly.toml configs

### DIFF
--- a/fly.cold-haze.toml
+++ b/fly.cold-haze.toml
@@ -1,27 +1,25 @@
-# fly.toml app configuration file generated for ref-sdk-api-test on 2025-01-31T15:33:05-06:00
+# fly.toml app configuration file generated for ref-sdk-test-cold-haze-1300-2 on 2025-03-19T16:25:48-05:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = 'ref-sdk-test-cold-haze-1300'
+app = 'ref-sdk-test-cold-haze-1300-2'
 primary_region = 'dfw'
 
 [build]
 
+[deploy]
+  release_command = 'npx prisma migrate deploy'
+
 [http_service]
-internal_port = 3000
-force_https = true
-auto_stop_machines = 'stop'
-auto_start_machines = true
-min_machines_running = 1
-max_machines_running = 5
-processes = ['app']
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ['app']
 
 [[vm]]
-memory = '2gb'
-swap_size_mb = 512
-cpu_kind = 'shared'
-cpus = 2
-
-[deploy]
-release_command = 'npx prisma migrate deploy'
+  memory = '2gb'
+  cpu_kind = 'shared'
+  cpus = 2

--- a/fly.toml
+++ b/fly.toml
@@ -1,26 +1,25 @@
-# fly.toml app configuration file generated for ref-sdk-api on 2024-12-12T11:23:30+01:00
+# fly.toml app configuration file generated for ref-sdk-api-2 on 2025-03-19T19:44:53-05:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = 'ref-sdk-api'
+app = 'ref-sdk-api-2'
 primary_region = 'ams'
 
 [build]
 
+[deploy]
+  release_command = 'npx prisma migrate deploy'
+
 [http_service]
-internal_port = 3000
-force_https = true
-auto_stop_machines = 'stop'
-auto_start_machines = true
-min_machines_running = 1
-processes = ['app']
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ['app']
 
 [[vm]]
-memory = '2gb'
-swap_size_mb = 512
-cpu_kind = 'shared'
-cpus = 2
-
-[deploy]
-release_command = 'npx prisma migrate deploy'
+  memory = '2gb'
+  cpu_kind = 'shared'
+  cpus = 2


### PR DESCRIPTION
Part of [#374](https://github.com/NEAR-DevHub/neardevhub-treasury-dashboard/issues/374)

I attempted to update the existing instance to the new organization. While the migration itself was smooth, moving the PostgreSQL database apps was challenging. Forking them wasn't an option, as cross-organization forks aren’t allowed.

I then followed the official documentation:

<img width="783" alt="Screenshot 2025-03-19 at 19 55 36" src="https://github.com/user-attachments/assets/aafbc544-a06c-4b6c-a619-e2e326039a76" />

But also restoring a snapshots from a different organization wasn't allowed. 

However, restoring snapshots from a different organization was also not permitted.

Additionally, all databases are running in "development" mode (a single machine instead of three) to reduce costs. Since the data is stored on-chain and can be easily reindexed if lost, this setup is intentional. However, it also means backups aren't supported, which I attempted but couldn't enable.

Given these constraints, I decided to redeploy instead, ensuring zero downtime—a significant advantage.

This PR itself isn’t critical, but we need to update references to ref-sdk-api by appending a two to the instances where it’s used.

@race-of-sloths include